### PR TITLE
Save sub as username, set `session.user` from global settings

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,6 +49,7 @@ async function authCallback(req, res) {
   const user_name = userinfo[oidc_settings.author_name_key];
   oidc_session.sub = sub;
   session.user = {
+    username: sub,
     name: user_name,
     is_admin: false,
   };


### PR DESCRIPTION
Benefits:

  * Seamless integration with authorization plugins that rely on the global user settings object or `req.session.user.username`.
  * Admin privileges can be given to OIDC users via `settings.json`:
    ```
    {
      "users": {
        // salsa.debian.org sub 5374 is rhansen
        "5374": {
          "is_admin": true
        }
      }
    }
    ```
  * The user's name can be set in `settings.json` in case the `author_name_key` claim doesn't exist in the OIDC user info:
    ```
    {
      "users": {
        "5374": {
          "name": "Richard Hansen"
        }
      }
    }
    ```
